### PR TITLE
Fix: Make background static on mobile devices

### DIFF
--- a/style.css
+++ b/style.css
@@ -47,14 +47,22 @@ body {
   color: var(--text-dark);
   transition: opacity 0.5s ease-in-out;
   padding: var(--spacing-unit);
-
-  /* FINAL BACKGROUND PROPERTIES */
   background-color: var(--neutral-bg);
-  background-image: url('assets/background.png');
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url(assets/background.png);
   background-attachment: fixed;
   background-position: top right;
   background-repeat: no-repeat;
-  background-size: 75%; /* Corrected size for corner placement */
+  background-size: 75%;
+  z-index: -2;
 }
 
 body.loading {
@@ -420,8 +428,8 @@ h1, h2, h3 {
 }
 
 @media (max-width: 768px) {
-  body {
-    background-size: 60%; /* Corrected size for corner placement */
+  body::before {
+    background-size: 60%;
   }
 
   .countdown {


### PR DESCRIPTION
The background image was scrolling with the content on mobile devices due to issues with `background-attachment: fixed`.

This commit fixes the issue by moving the background properties from the `body` to a `body::before` pseudo-element. This is a common workaround to ensure a static background on all devices, including mobile browsers that have issues with `background-attachment: fixed`.